### PR TITLE
Fix authentication on heartbeat failure

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -3,6 +3,8 @@ import { config } from 'dotenv';
 
 config();
 
-export default Axios.create({
-  baseURL: process.env.API_ENDPOINT,
-});
+export default () => {
+  return Axios.create({
+    baseURL: process.env.API_ENDPOINT,
+  });
+};

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -43,6 +43,10 @@ export async function heartbeat(): Promise<boolean> {
 export async function getProducts(
   quantity: number,
 ): Promise<ProductResponse | undefined> {
+  if (!(await heartbeat())) {
+    await authentication();
+  }
+
   const res = await client.get(
     `/products?limit=${quantity}&taken=false&desc=true`,
   );
@@ -58,6 +62,10 @@ export async function getOrder(
   product: Product,
   creation: OrderCreation,
 ): Promise<Order | undefined> {
+  if (!(await heartbeat())) {
+    await authentication();
+  }
+
   const res = await client.post(
     `/orders/${product.uuid}`,
     {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,3 +1,4 @@
+import { AxiosInstance } from 'axios';
 import { config } from 'dotenv';
 import querystring from 'querystring';
 import OrderCreation, {
@@ -5,11 +6,15 @@ import OrderCreation, {
   Product,
   ProductResponse,
 } from '../model/models';
-import client from './client';
+import AxiosClient from './client';
 
 config();
 
+let client: AxiosInstance;
+
 export async function authentication(): Promise<void> {
+  client = AxiosClient();
+
   const res = await client.post(
     '/auth/',
     querystring.stringify({
@@ -36,8 +41,12 @@ export async function authentication(): Promise<void> {
 }
 
 export async function heartbeat(): Promise<boolean> {
-  const res = await client.get('/hb/');
-  return res.status === 200 && res.data.valid;
+  try {
+    const res = await client.get('/hb/');
+    return res.status === 200 && res.data?.valid;
+  } catch (err) {
+    return false;
+  }
 }
 
 export async function getProducts(
@@ -48,7 +57,7 @@ export async function getProducts(
   }
 
   const res = await client.get(
-    `/products?limit=${quantity}&taken=false&desc=true`,
+    `/products/?limit=${quantity}&taken=false&desc=true`,
   );
 
   if (res.status === 200) {


### PR DESCRIPTION
closes #17 

O problema ocorria porque não havia renovação do token de acesso. Fazendo com que o bot recebesse um código 422 quando requisitada a API. Visto que quem usou o bot não tinha esse feedback, nem quem usou o comando e nem o usuário mencionado sabia o que tinha acontecido. Essa melhoria no feedback pode ser resolvida na issue #16.